### PR TITLE
Fixed potential errors on the catalog_product_entity_text_tmp_indexer table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [1.1.0] - 2025-06-19
+### Changed
+* Update text field length in table plugin
 ## [1.0.0] - 2024-03-28
 ### Added
 * Optimize flat table structure for both default and eav sourced product attributes

--- a/Plugin/Magento/Eav/Model/Entity/Attribute/Source/TablePlugin.php
+++ b/Plugin/Magento/Eav/Model/Entity/Attribute/Source/TablePlugin.php
@@ -12,18 +12,35 @@ class TablePlugin extends BasePlugin
 
     public function afterGetFlatColumns (\Magento\Eav\Model\Entity\Attribute\Source\Table $subject, array $result) : array
     {
-        if ($this->isEnabled() && $subject->getAttribute()->getFrontend()->getInputType() !== 'multiselect' && $connection = $this->attributeResource->getConnection()) {
+        if (!$this->isEnabled()) {
+            return $result;
+        }
+
+        $attribute = $subject->getAttribute();
+
+        if ($attribute->getFrontend()->getInputType() !== 'multiselect' && $connection = $this->attributeResource->getConnection()) {
             $optionTable = $connection->getTableName('eav_attribute_option');
             $optionValueTable = $connection->getTableName('eav_attribute_option_value');
             $select = $connection
                 ->select()
                 ->from($optionTable, [new Zend_Db_Expr("MAX(LENGTH($optionValueTable.value)) AS length")])
                 ->joinLeft($optionValueTable, $optionTable.'.option_id = '.$optionValueTable.'.option_id', 'value')
-                ->where($optionTable.'.attribute_id = ?', $subject->getAttribute()->getAttributeId());
+                ->where($optionTable.'.attribute_id = ?', $attribute->getAttributeId());
 
             $length = (int)$connection->fetchOne($select);
 
-            $result[$subject->getAttribute()->getAttributeCode() . '_value']['length'] = $length + $this->getMargin();
+            $result[$attribute->getAttributeCode() . '_value']['length'] = $length + $this->getMargin();
+        }
+
+        if($result[$attribute->getAttributeCode()]['type'] === 'text' && $result[$attribute->getAttributeCode()]['length'] == 255 && $connection = $this->attributeResource->getConnection()) {
+            $select = $connection
+                ->select()
+                ->from($attribute->getBackendTable(), [new Zend_Db_Expr("MAX(LENGTH(value)) AS length")])
+                ->where('attribute_id = ?', $attribute->getAttributeId());
+
+            $length = (int)$connection->fetchOne($select);
+
+            $result[$attribute->getAttributeCode()]['length'] = $length + $this->getMargin();
         }
 
         return $result;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # JustBetter OptimizeFlatTables
 
-This module checks the product attributes with backend type `varchar` used in the flat table and determines the length of the column. Instead of taking the default value of `255`.
+In Magento 2 when you want to index many text fields to the flat tables you could run into the `Syntax error or access violation: 1118 Row size too large (> 8126). Changing some columns to TEXT or BLOB may help.` error.
 
-If you have a lot of product attributes used in the flat table it could result in problems with the "Row Size being too large".
+The reason being every field taking up length for 255 characters while this is often not used.
+
+This module aims to reduce the chance of this happening by checking the product attributes with backend type `varchar` used in the flat table, and determine the actual length of the column. Instead of taking the default value of `255`.
+
+## Installation
+
+Run
+
+```shell
+composer require justbetter/magento2-optimizeflattable
+```
+
+After enabling the module your problems indexing to the flat tables should be resolved!


### PR DESCRIPTION
In the old version `Row size too large` would still occur when `catalog_product_entity_text_tmp_indexer` contains too many attributes as they would still be indexed as `varchar(255)` after this change the attributes in the tmp indexer will recieve the correct length too.